### PR TITLE
Add OpenCode alternative to local Claude setup guide

### DIFF
--- a/src/content/blog/2026-05-20-running-claude-code-locally-on-apple-silicon.md
+++ b/src/content/blog/2026-05-20-running-claude-code-locally-on-apple-silicon.md
@@ -325,3 +325,35 @@ The key flags are `-ngl 999` (GPU offload), `--mlock --no-mmap` (keep the model 
 ---
 
 *This post was written using Qwen3.6-35B-A3B running locally on a MacBook Pro with an M3 Pro chip (36 GB RAM).*
+
+## Addendum: Just Use OpenCode
+
+After going through all of this, there's a simpler path worth mentioning: [OpenCode](https://opencode.ai). It's an open-source terminal-based coding assistant that natively supports plugging in any OpenAI-compatible backend — including a local `llama-server` instance.
+
+Instead of wiring Claude Code up to a local model through an API proxy, you can drop an `opencode.json` config in your project and point it directly at your running server:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai-compatible": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "llama-server (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:8131/v1"
+      },
+      "models": {
+        "qwen3.6-coder": {
+          "name": "Qwen3.6 Coder (local)",
+          "limit": {
+            "context": 32768,
+            "output": 8192
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+That's it. OpenCode handles the rest — tool use, file edits, context management — without needing the Claude Code CLI or any API key. If your goal is a fully local, fully offline coding assistant, this is the lower-friction option.


### PR DESCRIPTION
## Summary

Added an addendum section to the "Running Claude Code Locally on Apple Silicon" blog post that introduces OpenCode as a simpler alternative for running a local coding assistant with OpenAI-compatible backends.

## Changes

- Added new "Addendum: Just Use OpenCode" section at the end of the post
- Included explanation of OpenCode as a lower-friction option compared to the Claude Code CLI setup
- Provided a complete `opencode.json` configuration example showing how to point OpenCode at a local `llama-server` instance
- Highlighted key benefits: no API key required, native tool use and file editing support, fully local/offline operation

## Details

The addendum acknowledges that while the main post covers a working setup, there's a simpler path using OpenCode that eliminates the need for API proxies and the Claude Code CLI entirely. The configuration example demonstrates practical usage with a local Qwen3.6 Coder model, making it immediately actionable for readers seeking a fully local coding assistant solution.

https://claude.ai/code/session_01AhdMmWijsPvprGMKtGoidV