### PR TITLE
Add References content type; migrate Spring compat cheatsheet

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,15 @@ import Hr from "./Hr.astro";
 import LinkButton from "./LinkButton.astro";
 
 export interface Props {
-  activeNav?: "posts" | "tags" | "about" | "search" | "cats" | "oss" | "projects";
+  activeNav?:
+    | "posts"
+    | "tags"
+    | "about"
+    | "search"
+    | "cats"
+    | "oss"
+    | "projects"
+    | "references";
 }
 
 const { activeNav } = Astro.props;
@@ -71,8 +79,19 @@ const { activeNav } = Astro.props;
             </a>
           </li>
           <li>
-            <a href="/projects/" class={activeNav === "projects" ? "active" : ""}>
+            <a
+              href="/projects/"
+              class={activeNav === "projects" ? "active" : ""}
+            >
               Projects
+            </a>
+          </li>
+          <li>
+            <a
+              href="/references/"
+              class={activeNav === "references" ? "active" : ""}
+            >
+              References
             </a>
           </li>
           <li>
@@ -150,7 +169,7 @@ const { activeNav } = Astro.props;
     @apply flex w-full flex-col items-center sm:ml-2 sm:flex-row sm:justify-end sm:space-x-4 sm:py-0;
   }
   nav ul {
-    @apply mt-4 grid w-44 grid-cols-2 grid-rows-4 gap-x-2 gap-y-2 sm:ml-0 sm:mt-0 sm:w-auto sm:gap-x-5 sm:gap-y-0;
+    @apply mt-4 grid w-44 grid-cols-2 grid-rows-5 gap-x-2 gap-y-2 sm:ml-0 sm:mt-0 sm:w-auto sm:gap-x-5 sm:gap-y-0;
   }
   nav ul li {
     @apply col-span-2 flex items-center justify-center;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -42,4 +42,21 @@ const projects = defineCollection({
   }),
 });
 
-export const collections = { blog, projects };
+const references = defineCollection({
+  type: "content_layer",
+  loader: glob({ pattern: "**/*.md", base: "./src/content/references" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    slug: z.string().optional(),
+    pubDatetime: z.date(),
+    modDatetime: z.date().optional().nullable(),
+    tags: z.array(z.string()).default([]),
+    ogImage: z.string().optional(),
+    featured: z.boolean().optional(),
+    draft: z.boolean().optional(),
+    order: z.number().default(0),
+  }),
+});
+
+export const collections = { blog, projects, references };

--- a/src/content/references/go-version-guide.md
+++ b/src/content/references/go-version-guide.md
@@ -21,6 +21,7 @@ painless.
 
 | Version                                | Released | Highlights                                                                                                       |
 | :------------------------------------- | :------- | :--------------------------------------------------------------------------------------------------------------- |
+| [1.26](https://go.dev/doc/go1.26)      | Feb 2026 | **Green Tea GC default** (10–40% GC overhead reduction), self-referential generics, `go fix` rewrite with modernizers, `crypto/hpke`, `errors.AsType()`, `log/slog.NewMultiHandler()`, post-quantum TLS hybrids default, ~30% faster cgo calls |
 | [1.25](https://go.dev/doc/go1.25)      | Aug 2025 | Container-aware `GOMAXPROCS`, experimental Green Tea GC, `testing/synctest` graduated, experimental `encoding/json/v2` |
 | [1.24](https://go.dev/doc/go1.24)      | Feb 2025 | Generic type aliases, faster Swiss Table maps, tool dependencies in `go.mod` (`go tool`), `os.Root`, weak pointers, FIPS 140-3 |
 | [1.23](https://go.dev/doc/go1.23)      | Aug 2024 | **Range-over-function iterators** (`iter`), `unique` package, timer/ticker GC improvements                       |
@@ -35,8 +36,7 @@ painless.
 | [1.5](https://go.dev/doc/go1.5)        | Aug 2015 | Compiler & runtime rewritten in Go, concurrent low-latency GC, `GOMAXPROCS` defaults to all CPUs                 |
 | [1.0](https://go.dev/doc/go1)          | Mar 2012 | First stable release &mdash; the Go 1 compatibility guarantee begins                                             |
 
-> **Go 1.26** is expected around **February 2026**. See the [release history](https://go.dev/doc/devel/release) for the
-> latest published versions and the [milestone tracker](https://github.com/golang/go/milestones) for what's landing.
+> **[Go 1.27](https://go.dev/doc/go1.27)** is expected around **August 2026**. Work-in-progress release notes are already published — highlights include generic methods, `encoding/json/v2` GA, a new `uuid` package, `crypto/mldsa` (post-quantum ML-DSA), and ~30% faster small allocations. See the [release history](https://go.dev/doc/devel/release) for the latest published versions and the [milestone tracker](https://github.com/golang/go/milestones) for what's landing.
 
 ## How Go Support Works
 

--- a/src/content/references/go-version-guide.md
+++ b/src/content/references/go-version-guide.md
@@ -1,0 +1,52 @@
+---
+title: Go Version Guide
+description: What's new in each major Go release, with support status marked and links to release notes.
+slug: go-version-guide
+pubDatetime: 2026-06-26T12:00:00.000Z
+modDatetime: 2026-06-26T12:00:00.000Z
+tags:
+  - golang
+order: 2
+---
+
+A scannable "what's new" for every major Go release. Go ships a major version roughly every **six months** (February
+and August) under the [Go 1 compatibility promise](https://go.dev/doc/go1compat), so upgrades are almost always
+painless.
+
+> **Go has no LTS.** The Go team provides security and critical bug fixes for the **two most recent** major releases
+> only. In practice, staying within one or two versions of the latest is the supported path &mdash; there is no
+> long-term branch to pin to. Version numbers below link to the official release notes.
+
+## Release History
+
+| Version                                | Released | Highlights                                                                                                       |
+| :------------------------------------- | :------- | :--------------------------------------------------------------------------------------------------------------- |
+| [1.25](https://go.dev/doc/go1.25)      | Aug 2025 | Container-aware `GOMAXPROCS`, experimental Green Tea GC, `testing/synctest` graduated, experimental `encoding/json/v2` |
+| [1.24](https://go.dev/doc/go1.24)      | Feb 2025 | Generic type aliases, faster Swiss Table maps, tool dependencies in `go.mod` (`go tool`), `os.Root`, weak pointers, FIPS 140-3 |
+| [1.23](https://go.dev/doc/go1.23)      | Aug 2024 | **Range-over-function iterators** (`iter`), `unique` package, timer/ticker GC improvements                       |
+| [1.22](https://go.dev/doc/go1.22)      | Feb 2024 | **Per-iteration loop variables**, range over integers, enhanced `net/http` routing patterns, `math/rand/v2`      |
+| [1.21](https://go.dev/doc/go1.21)      | Aug 2023 | `min`/`max`/`clear` builtins, `slices`/`maps`/`cmp` packages, structured logging (`log/slog`), PGO GA            |
+| [1.20](https://go.dev/doc/go1.20)      | Feb 2023 | `errors.Join` (wrapping multiple errors), profile-guided optimization (preview)                                  |
+| [1.18](https://go.dev/doc/go1.18)      | Mar 2022 | **Generics (type parameters)**, native fuzzing, multi-module workspaces                                          |
+| [1.16](https://go.dev/doc/go1.16)      | Feb 2021 | `embed` package, modules on by default, `io/fs` abstraction                                                      |
+| [1.13](https://go.dev/doc/go1.13)      | Sep 2019 | Error wrapping (`%w`, `errors.Is`/`errors.As`), new number literal syntax                                        |
+| [1.11](https://go.dev/doc/go1.11)      | Aug 2018 | **Go Modules** (experimental), WebAssembly port                                                                  |
+| [1.7](https://go.dev/doc/go1.7)        | Aug 2016 | `context` package moved into the standard library, SSA compiler backend                                          |
+| [1.5](https://go.dev/doc/go1.5)        | Aug 2015 | Compiler & runtime rewritten in Go, concurrent low-latency GC, `GOMAXPROCS` defaults to all CPUs                 |
+| [1.0](https://go.dev/doc/go1)          | Mar 2012 | First stable release &mdash; the Go 1 compatibility guarantee begins                                             |
+
+> **Go 1.26** is expected around **February 2026**. See the [release history](https://go.dev/doc/devel/release) for the
+> latest published versions and the [milestone tracker](https://github.com/golang/go/milestones) for what's landing.
+
+## How Go Support Works
+
+- **No LTS, no exceptions.** Only the latest two major releases get fixes. Upgrading promptly is the intended workflow.
+- The **compatibility promise** means code written for Go 1.x keeps compiling on later 1.y releases, which makes those
+  frequent upgrades low-risk.
+- Since 1.21, the **toolchain line in `go.mod`** lets a module request a minimum Go version and auto-download it.
+
+## Sources
+
+- [Go release history](https://go.dev/doc/devel/release) &mdash; official notes for every version
+- [Go release policy](https://go.dev/doc/devel/release#policy) &mdash; the two-release support window
+- [endoflife.date/go](https://endoflife.date/go) &mdash; support timelines

--- a/src/content/references/java-version-guide.md
+++ b/src/content/references/java-version-guide.md
@@ -1,0 +1,57 @@
+---
+title: Java Version Guide
+description: What's new in each Java release from 8 onward, with LTS versions marked and links to release notes.
+slug: java-version-guide
+pubDatetime: 2026-06-26T12:00:00.000Z
+modDatetime: 2026-06-26T12:00:00.000Z
+tags:
+  - java
+order: 1
+---
+
+A scannable "what's new" for every Java feature release since Java 8. Since Java 9, a new feature release ships every
+**six months** (March and September). **LTS** (Long-Term Support) releases &mdash; the ones most teams standardize on
+&mdash; now arrive every **two years** (17, 21, 25); earlier they were three years apart (8, 11, 17).
+
+Version numbers link to the official OpenJDK release page where available. For the full feature list of any release, see
+the [JEP index](https://openjdk.org/jeps/0).
+
+## Release History
+
+| Version                                          | Released | LTS         | Headline Features                                                                                                  |
+| :----------------------------------------------- | :------- | :---------- | :---------------------------------------------------------------------------------------------------------------- |
+| [25](https://openjdk.org/projects/jdk/25/)       | Sep 2025 | ✅ **LTS**  | Flexible constructor bodies, module import declarations, compact source files & instance `main`, scoped values    |
+| [24](https://openjdk.org/projects/jdk/24/)       | Mar 2025 | —           | Stream Gatherers (standard), Class-File API, quantum-resistant crypto (ML-KEM/ML-DSA), ahead-of-time class loading |
+| [23](https://openjdk.org/projects/jdk/23/)       | Sep 2024 | —           | Markdown in Javadoc, generational ZGC by default, primitive types in patterns (preview)                           |
+| [22](https://openjdk.org/projects/jdk/22/)       | Mar 2024 | —           | **Foreign Function & Memory API** (standard), unnamed variables & patterns, multi-file source programs            |
+| [21](https://openjdk.org/projects/jdk/21/)       | Sep 2023 | ✅ **LTS**  | **Virtual threads** (standard), record patterns, pattern matching for `switch`, sequenced collections             |
+| [20](https://openjdk.org/projects/jdk/20/)       | Mar 2023 | —           | Second previews of virtual threads, record patterns, scoped values                                                |
+| [19](https://openjdk.org/projects/jdk/19/)       | Sep 2022 | —           | Virtual threads (preview), structured concurrency (incubator), record patterns (preview)                          |
+| [18](https://openjdk.org/projects/jdk/18/)       | Mar 2022 | —           | UTF-8 as the default charset, simple web server (`jwebserver`), code snippets in Javadoc                          |
+| [17](https://openjdk.org/projects/jdk/17/)       | Sep 2021 | ✅ **LTS**  | **Sealed classes** (standard), new macOS/Metal rendering pipeline, strong encapsulation of JDK internals          |
+| [16](https://openjdk.org/projects/jdk/16/)       | Mar 2021 | —           | **Records** (standard), pattern matching for `instanceof` (standard), `Stream.toList()`, Unix-domain sockets      |
+| [15](https://openjdk.org/projects/jdk/15/)       | Sep 2020 | —           | **Text blocks** (standard), sealed classes (preview), ZGC & Shenandoah production-ready                            |
+| [14](https://openjdk.org/projects/jdk/14/)       | Mar 2020 | —           | Records (preview), pattern matching for `instanceof` (preview), switch expressions (standard), helpful NPEs       |
+| [13](https://openjdk.org/projects/jdk/13/)       | Sep 2019 | —           | Text blocks (preview), switch expressions (2nd preview), dynamic CDS archives                                     |
+| [12](https://openjdk.org/projects/jdk/12/)       | Mar 2019 | —           | Switch expressions (preview), Shenandoah GC (experimental), compact number formatting                            |
+| [11](https://openjdk.org/projects/jdk/11/)       | Sep 2018 | ✅ **LTS**  | Standardized **HTTP Client**, `var` in lambdas, single-file source launch, Flight Recorder, new `String` methods  |
+| [10](https://openjdk.org/projects/jdk/10/)       | Mar 2018 | —           | **`var`** local-variable type inference, application class-data sharing, parallel full GC for G1                   |
+| [9](https://openjdk.org/projects/jdk/9/)         | Sep 2017 | —           | **Module system (JPMS)**, JShell, collection factory methods (`List.of`), private interface methods               |
+| [8](https://www.oracle.com/java/technologies/javase/8-whats-new.html) | Mar 2014 | ✅ **LTS** | **Lambdas**, **Stream API**, `java.time`, default methods, `Optional`                                  |
+
+> **Java 26** is the next feature release, targeted for **March 2026**. It is non-LTS; the next LTS is **Java 27**
+> (September 2027). Check the [OpenJDK JDK project page](https://openjdk.org/projects/jdk/) for its finalized JEPs.
+
+## How Java Support Works
+
+- **Feature releases** ship every 6 months; each is supported only until the next one unless it's an LTS.
+- **LTS releases** (8, 11, 17, 21, 25, …) receive years of updates from Oracle and OpenJDK distributors (Adoptium /
+  Eclipse Temurin, Amazon Corretto, Azul Zulu, Microsoft, Red Hat, etc.). Most production systems run the latest LTS.
+- **Previews & incubators** are off by default and require `--enable-preview`. They can change or be removed before
+  standardization &mdash; don't ship them to production.
+
+## Sources
+
+- [OpenJDK JDK projects](https://openjdk.org/projects/jdk/) &mdash; per-release JEP lists
+- [JEP index](https://openjdk.org/jeps/0) &mdash; every JDK Enhancement Proposal
+- [endoflife.date/java](https://endoflife.date/java) &mdash; support and EOL timelines

--- a/src/content/references/java-version-guide.md
+++ b/src/content/references/java-version-guide.md
@@ -9,44 +9,218 @@ tags:
 order: 1
 ---
 
-A scannable "what's new" for every Java feature release since Java 8. Since Java 9, a new feature release ships every
-**six months** (March and September). **LTS** (Long-Term Support) releases &mdash; the ones most teams standardize on
-&mdash; now arrive every **two years** (17, 21, 25); earlier they were three years apart (8, 11, 17).
+A "what's new" for every Java feature release since Java 8. Since Java 9, a feature release ships every **six months**
+(March and September). **LTS** (Long-Term Support) releases &mdash; the ones most teams standardize on &mdash; now
+arrive every **two years**; earlier they were three years apart.
 
-Version numbers link to the official OpenJDK release page where available. For the full feature list of any release, see
-the [JEP index](https://openjdk.org/jeps/0).
+**LTS line:** 8 &middot; 11 &middot; 17 &middot; 21 &middot; 25 (next: **27** in 2027). Expand any release below for its
+highlights and a link to the release notes. For the complete picture of any version, see the
+[JEP index](https://openjdk.org/jeps/0).
 
-## Release History
+## Releases
 
-| Version                                          | Released | LTS         | Headline Features                                                                                                  |
-| :----------------------------------------------- | :------- | :---------- | :---------------------------------------------------------------------------------------------------------------- |
-| [25](https://openjdk.org/projects/jdk/25/)       | Sep 2025 | ✅ **LTS**  | Flexible constructor bodies, module import declarations, compact source files & instance `main`, scoped values    |
-| [24](https://openjdk.org/projects/jdk/24/)       | Mar 2025 | —           | Stream Gatherers (standard), Class-File API, quantum-resistant crypto (ML-KEM/ML-DSA), ahead-of-time class loading |
-| [23](https://openjdk.org/projects/jdk/23/)       | Sep 2024 | —           | Markdown in Javadoc, generational ZGC by default, primitive types in patterns (preview)                           |
-| [22](https://openjdk.org/projects/jdk/22/)       | Mar 2024 | —           | **Foreign Function & Memory API** (standard), unnamed variables & patterns, multi-file source programs            |
-| [21](https://openjdk.org/projects/jdk/21/)       | Sep 2023 | ✅ **LTS**  | **Virtual threads** (standard), record patterns, pattern matching for `switch`, sequenced collections             |
-| [20](https://openjdk.org/projects/jdk/20/)       | Mar 2023 | —           | Second previews of virtual threads, record patterns, scoped values                                                |
-| [19](https://openjdk.org/projects/jdk/19/)       | Sep 2022 | —           | Virtual threads (preview), structured concurrency (incubator), record patterns (preview)                          |
-| [18](https://openjdk.org/projects/jdk/18/)       | Mar 2022 | —           | UTF-8 as the default charset, simple web server (`jwebserver`), code snippets in Javadoc                          |
-| [17](https://openjdk.org/projects/jdk/17/)       | Sep 2021 | ✅ **LTS**  | **Sealed classes** (standard), new macOS/Metal rendering pipeline, strong encapsulation of JDK internals          |
-| [16](https://openjdk.org/projects/jdk/16/)       | Mar 2021 | —           | **Records** (standard), pattern matching for `instanceof` (standard), `Stream.toList()`, Unix-domain sockets      |
-| [15](https://openjdk.org/projects/jdk/15/)       | Sep 2020 | —           | **Text blocks** (standard), sealed classes (preview), ZGC & Shenandoah production-ready                            |
-| [14](https://openjdk.org/projects/jdk/14/)       | Mar 2020 | —           | Records (preview), pattern matching for `instanceof` (preview), switch expressions (standard), helpful NPEs       |
-| [13](https://openjdk.org/projects/jdk/13/)       | Sep 2019 | —           | Text blocks (preview), switch expressions (2nd preview), dynamic CDS archives                                     |
-| [12](https://openjdk.org/projects/jdk/12/)       | Mar 2019 | —           | Switch expressions (preview), Shenandoah GC (experimental), compact number formatting                            |
-| [11](https://openjdk.org/projects/jdk/11/)       | Sep 2018 | ✅ **LTS**  | Standardized **HTTP Client**, `var` in lambdas, single-file source launch, Flight Recorder, new `String` methods  |
-| [10](https://openjdk.org/projects/jdk/10/)       | Mar 2018 | —           | **`var`** local-variable type inference, application class-data sharing, parallel full GC for G1                   |
-| [9](https://openjdk.org/projects/jdk/9/)         | Sep 2017 | —           | **Module system (JPMS)**, JShell, collection factory methods (`List.of`), private interface methods               |
-| [8](https://www.oracle.com/java/technologies/javase/8-whats-new.html) | Mar 2014 | ✅ **LTS** | **Lambdas**, **Stream API**, `java.time`, default methods, `Optional`                                  |
+<details class="ref-box" open>
+<summary><span class="ref-box-title">Java 25</span><span class="ref-box-date">Sep 2025</span><span class="ref-box-lts">LTS</span></summary>
 
-> **Java 26** is the next feature release, targeted for **March 2026**. It is non-LTS; the next LTS is **Java 27**
-> (September 2027). Check the [OpenJDK JDK project page](https://openjdk.org/projects/jdk/) for its finalized JEPs.
+- **Flexible constructor bodies** — run statements before `this()`/`super()` ([JEP 513](https://openjdk.org/jeps/513))
+- **Module import declarations** — `import module M` to pull in a module's exported packages ([JEP 511](https://openjdk.org/jeps/511))
+- **Compact source files & instance `main` methods** — much smaller "hello world", great for learning ([JEP 512](https://openjdk.org/jeps/512))
+- **Scoped values** standardized — a safer, immutable alternative to thread-locals ([JEP 506](https://openjdk.org/jeps/506))
+- Still in preview: primitive types in patterns, structured concurrency, stable values
+
+[Release notes →](https://openjdk.org/projects/jdk/25/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 24</span><span class="ref-box-date">Mar 2025</span></summary>
+
+- **Stream Gatherers** standardized — custom intermediate stream operations ([JEP 485](https://openjdk.org/jeps/485))
+- **Class-File API** standardized — parse/generate `.class` files without ASM ([JEP 484](https://openjdk.org/jeps/484))
+- Quantum-resistant cryptography: ML-KEM ([JEP 496](https://openjdk.org/jeps/496)) and ML-DSA ([JEP 497](https://openjdk.org/jeps/497))
+- **Ahead-of-time class loading & linking** — faster startup, part of Project Leyden ([JEP 483](https://openjdk.org/jeps/483))
+- Compact object headers (experimental); the Security Manager is now permanently disabled
+
+[Release notes →](https://openjdk.org/projects/jdk/24/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 23</span><span class="ref-box-date">Sep 2024</span></summary>
+
+- **Markdown in Javadoc** — write doc comments in Markdown ([JEP 467](https://openjdk.org/jeps/467))
+- Generational ZGC becomes the default mode ([JEP 474](https://openjdk.org/jeps/474))
+- Primitive types in patterns, `instanceof`, and `switch` (preview)
+
+[Release notes →](https://openjdk.org/projects/jdk/23/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 22</span><span class="ref-box-date">Mar 2024</span></summary>
+
+- **Foreign Function & Memory API** standardized — call native code and manage off-heap memory, no JNI ([JEP 454](https://openjdk.org/jeps/454))
+- **Unnamed variables & patterns** (`_`) standardized ([JEP 456](https://openjdk.org/jeps/456))
+- Multi-file source-code programs via `java` launcher; statements before `super()` (preview)
+
+[Release notes →](https://openjdk.org/projects/jdk/22/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 21</span><span class="ref-box-date">Sep 2023</span><span class="ref-box-lts">LTS</span></summary>
+
+- **Virtual threads** standardized — cheap, massively scalable concurrency ([JEP 444](https://openjdk.org/jeps/444))
+- **Record patterns** standardized — destructure records in `switch`/`instanceof` ([JEP 440](https://openjdk.org/jeps/440))
+- **Pattern matching for `switch`** standardized ([JEP 441](https://openjdk.org/jeps/441))
+- **Sequenced collections** — uniform first/last access ([JEP 431](https://openjdk.org/jeps/431))
+- Generational ZGC; string templates & unnamed patterns (preview)
+
+[Release notes →](https://openjdk.org/projects/jdk/21/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 20</span><span class="ref-box-date">Mar 2023</span></summary>
+
+- Second previews of virtual threads, record patterns, and pattern matching for `switch`
+- Scoped values (incubator)
+
+[Release notes →](https://openjdk.org/projects/jdk/20/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 19</span><span class="ref-box-date">Sep 2022</span></summary>
+
+- Virtual threads (preview) and structured concurrency (incubator) debut
+- Record patterns (preview); pattern matching for `switch` (preview); FFM API (preview)
+
+[Release notes →](https://openjdk.org/projects/jdk/19/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 18</span><span class="ref-box-date">Mar 2022</span></summary>
+
+- **UTF-8 as the default charset** everywhere ([JEP 400](https://openjdk.org/jeps/400))
+- Simple web server (`jwebserver`) for quick static hosting; code snippets in Javadoc
+
+[Release notes →](https://openjdk.org/projects/jdk/18/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 17</span><span class="ref-box-date">Sep 2021</span><span class="ref-box-lts">LTS</span></summary>
+
+- **Sealed classes** standardized — restrict which types can extend/implement ([JEP 409](https://openjdk.org/jeps/409))
+- New macOS rendering pipeline (Metal); strong encapsulation of JDK internals
+- The long-time baseline for Spring Boot 3.x and much of the modern ecosystem
+
+[Release notes →](https://openjdk.org/projects/jdk/17/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 16</span><span class="ref-box-date">Mar 2021</span></summary>
+
+- **Records** standardized ([JEP 395](https://openjdk.org/jeps/395)); **pattern matching for `instanceof`** standardized ([JEP 394](https://openjdk.org/jeps/394))
+- `Stream.toList()`, Unix-domain socket channels, Vector API (incubator)
+
+[Release notes →](https://openjdk.org/projects/jdk/16/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 15</span><span class="ref-box-date">Sep 2020</span></summary>
+
+- **Text blocks** standardized — multi-line string literals ([JEP 378](https://openjdk.org/jeps/378))
+- Sealed classes (preview); ZGC and Shenandoah become production-ready
+
+[Release notes →](https://openjdk.org/projects/jdk/15/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 14</span><span class="ref-box-date">Mar 2020</span></summary>
+
+- Records and pattern matching for `instanceof` debut (preview)
+- **Switch expressions** standardized ([JEP 361](https://openjdk.org/jeps/361)); helpful `NullPointerException` messages
+
+[Release notes →](https://openjdk.org/projects/jdk/14/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 13</span><span class="ref-box-date">Sep 2019</span></summary>
+
+- Text blocks (preview); switch expressions (second preview)
+- Dynamic CDS archives
+
+[Release notes →](https://openjdk.org/projects/jdk/13/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 12</span><span class="ref-box-date">Mar 2019</span></summary>
+
+- Switch expressions (preview); Shenandoah GC (experimental)
+- Compact number formatting
+
+[Release notes →](https://openjdk.org/projects/jdk/12/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 11</span><span class="ref-box-date">Sep 2018</span><span class="ref-box-lts">LTS</span></summary>
+
+- **Standardized HTTP Client** (`java.net.http`) with HTTP/2 and WebSocket ([JEP 321](https://openjdk.org/jeps/321))
+- `var` allowed in lambda parameters; run a single source file directly (`java Foo.java`)
+- Flight Recorder open-sourced; new `String` methods (`isBlank`, `strip`, `lines`, `repeat`)
+
+[Release notes →](https://openjdk.org/projects/jdk/11/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 10</span><span class="ref-box-date">Mar 2018</span></summary>
+
+- **`var`** — local-variable type inference ([JEP 286](https://openjdk.org/jeps/286))
+- Application class-data sharing; parallel full GC for G1
+
+[Release notes →](https://openjdk.org/projects/jdk/10/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 9</span><span class="ref-box-date">Sep 2017</span></summary>
+
+- **Module system (JPMS / Project Jigsaw)** ([JEP 261](https://openjdk.org/jeps/261))
+- JShell (the REPL); collection factory methods (`List.of`, `Map.of`); private interface methods
+
+[Release notes →](https://openjdk.org/projects/jdk/9/)
+
+</details>
+
+<details class="ref-box">
+<summary><span class="ref-box-title">Java 8</span><span class="ref-box-date">Mar 2014</span><span class="ref-box-lts">LTS</span></summary>
+
+- **Lambda expressions** and the **Stream API** — the biggest language shift in Java's history
+- The `java.time` (JSR-310) date/time API; default methods on interfaces; `Optional`
+- Still widely deployed; the last LTS before the modular era
+
+[What's new in Java 8 →](https://www.oracle.com/java/technologies/javase/8-whats-new.html)
+
+</details>
+
+> **Java 26** is the next feature release, targeted for **March 2026** (non-LTS; the next LTS is **Java 27** in
+> September 2027). Check the [OpenJDK JDK project page](https://openjdk.org/projects/jdk/) for its finalized JEPs.
 
 ## How Java Support Works
 
 - **Feature releases** ship every 6 months; each is supported only until the next one unless it's an LTS.
-- **LTS releases** (8, 11, 17, 21, 25, …) receive years of updates from Oracle and OpenJDK distributors (Adoptium /
-  Eclipse Temurin, Amazon Corretto, Azul Zulu, Microsoft, Red Hat, etc.). Most production systems run the latest LTS.
+- **LTS releases** (8, 11, 17, 21, 25, …) receive years of updates from OpenJDK distributors &mdash; Adoptium / Eclipse
+  Temurin, Amazon Corretto, Azul Zulu, Microsoft, Red Hat, and others. Most production systems run the latest LTS.
 - **Previews & incubators** are off by default and require `--enable-preview`. They can change or be removed before
   standardization &mdash; don't ship them to production.
 

--- a/src/content/references/python-version-guide.md
+++ b/src/content/references/python-version-guide.md
@@ -1,0 +1,50 @@
+---
+title: Python Version Guide
+description: What's new in each Python 3 release, with support status marked and links to the official What's New notes.
+slug: python-version-guide
+pubDatetime: 2026-06-26T12:00:00.000Z
+modDatetime: 2026-06-26T12:00:00.000Z
+tags:
+  - python
+order: 3
+---
+
+A scannable "what's new" for modern Python 3 releases. Python ships one feature release per year (every **October**).
+
+> **Python has no LTS**, but every release gets a fixed **~5-year** support window: roughly 2 years of bug fixes
+> followed by 3 years of security-only fixes. For exact dates always check the
+> [official version status page](https://devguide.python.org/versions/). Version numbers below link to the "What's New"
+> notes.
+
+## Release History
+
+| Version                                                          | Released | Status        | Highlights                                                                                                |
+| :-------------------------------------------------------------- | :------- | :------------ | :-------------------------------------------------------------------------------------------------------- |
+| [3.14](https://docs.python.org/3/whatsnew/3.14.html)            | Oct 2025 | Active        | **Template strings (t-strings)**, free-threading officially supported, deferred annotation evaluation, `concurrent.interpreters` |
+| [3.13](https://docs.python.org/3/whatsnew/3.13.html)            | Oct 2024 | Active        | Experimental **free-threaded (no-GIL)** build, experimental JIT, new interactive REPL, better error messages |
+| [3.12](https://docs.python.org/3/whatsnew/3.12.html)            | Oct 2023 | Security-only | Type parameter syntax (PEP 695), per-interpreter GIL, improved f-strings, `type` statement                |
+| [3.11](https://docs.python.org/3/whatsnew/3.11.html)            | Oct 2022 | Security-only | **10–60% faster** (Faster CPython), exception groups & `except*`, fine-grained tracebacks, `tomllib`      |
+| [3.10](https://docs.python.org/3/whatsnew/3.10.html)            | Oct 2021 | Security-only | **Structural pattern matching** (`match`/`case`), much better error messages, `X \| Y` union types        |
+| [3.9](https://docs.python.org/3/whatsnew/3.9.html)             | Oct 2020 | End of life   | Dict union operators (`\|`), builtin generic types (`list[int]`), `zoneinfo`, `str.removeprefix/suffix`   |
+| [3.8](https://docs.python.org/3/whatsnew/3.8.html)             | Oct 2019 | End of life   | Walrus operator (`:=`), positional-only params (`/`), f-string `=` debugging, `typing.Protocol`           |
+| [3.7](https://docs.python.org/3/whatsnew/3.7.html)             | Jun 2018 | End of life   | `dataclasses`, `breakpoint()`, deferred annotation imports, guaranteed dict ordering                      |
+| [3.6](https://docs.python.org/3/whatsnew/3.6.html)             | Dec 2016 | End of life   | **f-strings**, variable annotations, async generators & comprehensions, `secrets`                         |
+
+> **Python 3.15** is due **October 2026**. Status labels above are approximate &mdash; the
+> [devguide version page](https://devguide.python.org/versions/) is the source of truth for bugfix vs. security-only vs.
+> EOL dates.
+
+## How Python Support Works
+
+- **No LTS branch.** Each annual release follows the same lifecycle: ~24 months of bug-fix releases, then security-only
+  patches until it reaches roughly 5 years old.
+- The **latest one or two releases** are the ones receiving regular bug fixes (the "Active" rows above). Older supported
+  versions get security fixes only.
+- **Free-threading** (PEP 703 / 779) is the big ongoing shift: experimental in 3.13, officially supported in 3.14. It
+  removes the GIL but is still opt-in via a separate build.
+
+## Sources
+
+- [Python version status](https://devguide.python.org/versions/) &mdash; authoritative support & EOL dates
+- [What's New in Python](https://docs.python.org/3/whatsnew/) &mdash; full release notes
+- [endoflife.date/python](https://endoflife.date/python) &mdash; support timelines

--- a/src/content/references/spring-version-compatibility.md
+++ b/src/content/references/spring-version-compatibility.md
@@ -1,43 +1,33 @@
 ---
-author: StevenPG
-pubDatetime: 2025-05-04T12:00:00.000Z
-modDatetime: 2026-06-19T12:00:00.000Z
 title: Spring Version Compatibility Cheatsheet
-slug: spring-compat-cheatsheet
-featured: false
-ogImage: /assets/default-og-image.png
+description: A continuously updated reference for aligning Java, Gradle, Spring Boot, and Spring Cloud versions.
+slug: spring-version-compatibility
+pubDatetime: 2025-05-04T12:00:00.000Z
+modDatetime: 2026-06-26T12:00:00.000Z
 tags:
   - gradle
   - java
   - spring
-description: A continuously updated page for easy reference!
-canonicalURL: https://stevenpg.com/references/spring-version-compatibility/
+order: 0
 ---
-
-> **📌 This cheatsheet now lives on its own continuously updated reference page:
-> [Spring Version Compatibility Cheatsheet](/references/spring-version-compatibility/).**
-> Head there for the latest tables — that page is kept current as new Java, Gradle,
-> Spring Boot, and Spring Cloud versions ship. This post is kept for historical context.
-
-# Getting Versions Aligned: Java, Gradle, Spring Boot, and Spring Cloud
 
 Using Spring Boot and Spring Cloud can significantly speed up Java development, particularly for microservices. However,
 managing the dependencies between your JDK, build tool (like Gradle or Maven), Spring Boot, and Spring Cloud requires
 attention to detail. Version mismatches are a common source of problems, leading to build failures or runtime errors
 that can be difficult to diagnose.
 
-This post outlines the compatibility requirements you need to be aware of, explains common errors caused by mismatches,
-provides methods for resolving them, and includes specific compatibility information for Gradle, Java, Spring Boot, and
-Spring Cloud.
+This page collects the compatibility tables I reach for most often. I keep it updated as new versions ship, so bookmark
+it rather than relying on a snapshot.
 
 ### Table Shortcuts
 
-* [Gradle and Java Compatibility](#gradle-and-java-compatibility)
-* [Java Version Compatibility with Spring Boot](#java-version-compatibility-with-spring-boot)
-* [Spring Cloud Compatibility with Spring Boot](#spring-cloud-compatibility-with-spring-boot)
+- [Java Version Compatibility with Spring Boot](#java-version-compatibility-with-spring-boot)
+- [Spring Cloud Compatibility with Spring Boot](#spring-cloud-compatibility-with-spring-boot)
+- [Gradle and Java Compatibility](#gradle-and-java-compatibility)
 
 ### Spring Support Mapping
-Spring has now published a [compatibility list](https://spring.io/projects/generations) 
+
+Spring has now published a [compatibility list](https://spring.io/projects/generations)
 called Spring Support Mapping. It provides a matrix of which versions of different Spring dependencies
 are compatible with each other, including Spring Boot, Spring Framework and Spring Cloud.
 
@@ -46,7 +36,7 @@ are compatible with each other, including Spring Boot, Spring Framework and Spri
 ### Java Version Compatibility with Spring Boot
 
 | Spring Boot Version | Compatible Java Versions (Min - Max Targeted) |
-|:--------------------|:----------------------------------------------|
+| :------------------ | :-------------------------------------------- |
 | 4.1.x               | Java 17 - 26                                  |
 | 4.0.x               | Java 17 - 25                                  |
 | 3.5.x               | Java 17 - 25                                  |
@@ -79,24 +69,24 @@ Do not arbitrarily combine Spring Cloud trains and Spring Boot versions.
 Always check the documentation page for the specific Spring Cloud release train (e.g., 2023.0.1) to find its required
 Spring Boot version.
 
-| Spring Cloud Release Train                                                                                  | Corresponding Spring Boot Version                                                      |
-|:------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------|
+| Spring Cloud Release Train                                                                                  | Corresponding Spring Boot Version                                             |
+| :---------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
 | [2025.1.x (Oakwood)](https://spring.io/blog/2025/11/25/spring-cloud-2025-1-0-aka-oakwood-has-been-released) | [Spring Boot 4.0.x / 4.1.x](https://spring.io/blog/2026/06/10/spring-boot-4/) |
-| [2025.0.x (Northfields)](https://spring.io/blog/2025/05/29/spring-cloud-2025-0-0-is-abvailable)             | Spring Boot 3.5.x                                                                      |
-| [2024.0.x (Moorgate)](https://spring.io/blog/2024/12/03/spring-cloud-2024-0-0)                              | Spring Boot 3.4.x                                                                      |
-| [2023.0.x (Leyton)](https://spring.io/blog/2023/12/06/spring-cloud-2023-0-0-aka-leyton-is-now-available)    | Spring Boot 3.2.x / 3.3.x                                                              |
-| 2022.0.x (Kilburn)                                                                                          | Spring Boot 3.0.x / 3.1.x                                                              |
-| 2021.0.x (Jubilee)                                                                                          | Spring Boot 2.6.x / 2.7.x                                                              |
-| 2020.0.x (Ilford)                                                                                           | Spring Boot 2.4.x / 2.5.x                                                              |
-| Hoxton                                                                                                      | Spring Boot 2.2.x / 2.3.x                                                              |
-| Greenwich                                                                                                   | Spring Boot 2.1.x                                                                      |
-| Finchley                                                                                                    | Spring Boot 2.0.x                                                                      |
-| Edgware                                                                                                     | Spring Boot 1.5.x                                                                      |
+| [2025.0.x (Northfields)](https://spring.io/blog/2025/05/29/spring-cloud-2025-0-0-is-abvailable)             | Spring Boot 3.5.x                                                             |
+| [2024.0.x (Moorgate)](https://spring.io/blog/2024/12/03/spring-cloud-2024-0-0)                              | Spring Boot 3.4.x                                                             |
+| [2023.0.x (Leyton)](https://spring.io/blog/2023/12/06/spring-cloud-2023-0-0-aka-leyton-is-now-available)    | Spring Boot 3.2.x / 3.3.x                                                     |
+| 2022.0.x (Kilburn)                                                                                          | Spring Boot 3.0.x / 3.1.x                                                     |
+| 2021.0.x (Jubilee)                                                                                          | Spring Boot 2.6.x / 2.7.x                                                     |
+| 2020.0.x (Ilford)                                                                                           | Spring Boot 2.4.x / 2.5.x                                                     |
+| Hoxton                                                                                                      | Spring Boot 2.2.x / 2.3.x                                                     |
+| Greenwich                                                                                                   | Spring Boot 2.1.x                                                             |
+| Finchley                                                                                                    | Spring Boot 2.0.x                                                             |
+| Edgware                                                                                                     | Spring Boot 1.5.x                                                             |
 
 ### Gradle and Java Compatibility
 
 | Gradle Version | Latest Supported Java Version |
-|:---------------|:------------------------------|
+| :------------- | :---------------------------- |
 | 9.4            | Java 26                       |
 | 9.1            | Java 25                       |
 | 8.14           | Java 24                       |
@@ -112,7 +102,7 @@ Spring Boot version.
 
 Key Points:
 
-- The table lists the Gradle version that *first* added support for running on each Java release. The latest Gradle
+- The table lists the Gradle version that _first_ added support for running on each Java release. The latest Gradle
   release is 9.6 (June 2026), which can run on any JDK from 17 through 26.
 - Newer Gradle versions are generally required to support newer Java versions for running Gradle itself.
 - While you might run Gradle 9 on JDK 25, you can still configure it to compile your project code for Java 17 or Java 21
@@ -133,41 +123,22 @@ this, adding its own layer of managed dependencies. These systems work reliably 
 - Transitive Dependencies: The dependencies managed by Spring Boot and Spring Cloud have their own dependencies. A
   mismatch anywhere in this chain can cause conflicts.
 
-## Gradle and Java
-
-Before even considering Spring Boot, your build tool itself needs a compatible JDK to run. Gradle, like any Java
-application, has minimum and recommended Java versions. Furthermore, Gradle supports compiling and testing code using
-different Java versions than the one it runs on, configured via Java toolchains.
-
-- Running Gradle: You need a compatible JDK installed and typically configured via JAVA_HOME or the Gradle daemon
-  settings.
-
-- Building Code: You configure sourceCompatibility and targetCompatibility in your build.gradle file, and ideally use
-  Gradle's Java toolchain support to ensure Gradle downloads and uses the specified JDK version for compilation and
-  testing, regardless of the JDK it's running on.
-
 ### Common Errors from Version Mismatches
 
 When versions aren't correctly aligned between Java, your build tool, Spring Boot, and potentially Spring Cloud, you
 might encounter errors like:
 
-- java.lang.ClassNotFoundException: The JVM can't find a specific class file at runtime. This often points to a missing
+- `java.lang.ClassNotFoundException`: The JVM can't find a specific class file at runtime. This often points to a missing
   dependency or an incorrect version being loaded.
-
-- java.lang.NoSuchMethodError: Code calls a method that existed at compile time, but is missing in the version of the
+- `java.lang.NoSuchMethodError`: Code calls a method that existed at compile time, but is missing in the version of the
   library loaded at runtime. A classic sign of a version conflict.
-
-- java.lang.AbstractMethodError: An attempt was made to call an abstract method, which can happen if library APIs
+- `java.lang.AbstractMethodError`: An attempt was made to call an abstract method, which can happen if library APIs
   changed between versions in incompatible ways.
-
 - Compilation Failures: Often related to using Java language features not supported by the configured
-  targetCompatibility bytecode level, or when Spring Boot/Cloud versions require APIs from a newer JDK than you're
-  using.
-
+  targetCompatibility bytecode level, or when Spring Boot/Cloud versions require APIs from a newer JDK than you're using.
 - Build Tool Errors: Gradle or Maven might fail if they are run with an incompatible JDK version (e.g., running Gradle 6
   with JDK 17 might cause issues).
-
-- Spring Framework Issues: Problems like UnsatisfiedDependencyException or BeanCreationException during application
+- Spring Framework Issues: Problems like `UnsatisfiedDependencyException` or `BeanCreationException` during application
   startup can sometimes stem from underlying library incompatibilities caused by version mismatches.
 
 ### Resolving Compatibility Issues
@@ -176,19 +147,15 @@ Troubleshooting version conflicts involves a systematic approach:
 
 - Consult Official Documentation: This is the primary source of truth. Check the specific version requirements for
   Gradle, Spring Boot, and Spring Cloud.
-
 - Use Spring Initializr: For new projects, start.spring.io pre-selects compatible versions, providing a solid starting
   point.
-
 - Utilize Maven/Gradle BOMs: Import the spring-boot-dependencies Bill of Materials (BOM) and, if used, the
   spring-cloud-dependencies BOM for your specific release train. This helps ensure consistent versions for transitive
-  dependencies. It's generally recommended to let these BOMs manage versions unless you have a specific reason to
-  override one.
+  dependencies.
 
 Maven Example (pom.xml)
 
 ```xml
-
 <dependencyManagement>
     <dependencies>
         <dependency>
@@ -221,24 +188,13 @@ dependencyManagement {
 }
 ```
 
-- Inspect the Dependency Tree: Use mvn dependency:tree or gradle dependencies (or gradle buildEnvironment) to see the
-  resolved dependency versions. Identify conflicts where different versions of the same library are being requested. Use
-  exclusions or explicitly declare needed versions if necessary.
-
+- Inspect the Dependency Tree: Use `mvn dependency:tree` or `gradle dependencies` (or `gradle buildEnvironment`) to see
+  the resolved dependency versions. Identify conflicts where different versions of the same library are being requested.
 - Verify Build Tool Configuration: Ensure your Gradle or Maven setup is compatible with the JDK you're using to run the
   build. For Gradle, explicitly configure Java toolchains for compiling and testing.
-
 - Test Consistently: Implement unit and integration tests to catch runtime errors early.
 
-
-## Final Thoughts
-
-Managing version compatibility in the Java and Spring ecosystem is a necessary part of development. While tools like
-Spring Boot and Gradle significantly help, understanding the requirements and relationships between the JDK, build tool,
-Spring Boot, and Spring Cloud is key to avoiding common problems.
-
-Prioritize checking official documentation, utilize BOMs for dependency management, inspect your build environment when
-issues arise, and maintain robust testing practices. This diligence helps ensure a smoother development process.
+---
 
 Disclaimer: Version compatibility information changes. Always refer to the official documentation for Gradle, Spring
 Boot, and Spring Cloud for the most accurate and up-to-date details pertinent to your project.

--- a/src/content/references/spring-version-compatibility.md
+++ b/src/content/references/spring-version-compatibility.md
@@ -11,29 +11,15 @@ tags:
 order: 0
 ---
 
-Using Spring Boot and Spring Cloud can significantly speed up Java development, particularly for microservices. However,
-managing the dependencies between your JDK, build tool (like Gradle or Maven), Spring Boot, and Spring Cloud requires
-attention to detail. Version mismatches are a common source of problems, leading to build failures or runtime errors
-that can be difficult to diagnose.
+Quick lookup tables for aligning your JDK, Gradle, Spring Boot, and Spring Cloud versions. Kept current as new versions
+ship &mdash; bookmark it. For the official, authoritative matrix, see Spring's
+[Support Mapping](https://spring.io/projects/generations).
 
-This page collects the compatibility tables I reach for most often. I keep it updated as new versions ship, so bookmark
-it rather than relying on a snapshot.
+**Jump to:** [Spring Boot &harr; Java](#spring-boot--java) &middot;
+[Spring Cloud &harr; Spring Boot](#spring-cloud--spring-boot) &middot;
+[Gradle &harr; Java](#gradle--java)
 
-### Table Shortcuts
-
-- [Java Version Compatibility with Spring Boot](#java-version-compatibility-with-spring-boot)
-- [Spring Cloud Compatibility with Spring Boot](#spring-cloud-compatibility-with-spring-boot)
-- [Gradle and Java Compatibility](#gradle-and-java-compatibility)
-
-### Spring Support Mapping
-
-Spring has now published a [compatibility list](https://spring.io/projects/generations)
-called Spring Support Mapping. It provides a matrix of which versions of different Spring dependencies
-are compatible with each other, including Spring Boot, Spring Framework and Spring Cloud.
-
-## Compatibility Reference Tables
-
-### Java Version Compatibility with Spring Boot
+## Spring Boot &harr; Java
 
 | Spring Boot Version | Compatible Java Versions (Min - Max Targeted) |
 | :------------------ | :-------------------------------------------- |
@@ -52,22 +38,10 @@ are compatible with each other, including Spring Boot, Spring Framework and Spri
 | 2.0.x               | Java 8 - 9                                    |
 | 1.5.x               | Java 6 - 8                                    |
 
-Key Notes:
+Spring Boot 4.x and 3.x baseline on Java 17. Source:
+[endoflife.date](https://endoflife.date/spring-boot#java-compatibility).
 
-- Spring Boot 4.x and 3.x both require Java 17 as a baseline. Spring Boot 4.x runs on Spring Framework 7
-  and tracks the latest JDKs (4.1.x adds Java 26 support; first-class/native-image support is tested on Java 25).
-- Spring Boot 2.x supports Java 8 but is tested with newer JDKs up to specific versions.
-
-Reference doc (https://endoflife.date/spring-boot#java-compatibility)
-
-### Spring Cloud Compatibility with Spring Boot
-
-Spring Cloud uses "Release Trains" (e.g., 2023.0.x). Each train corresponds to specific Spring Boot versions. Mixing
-versions not intended to work together is highly likely to cause issues.
-
-Do not arbitrarily combine Spring Cloud trains and Spring Boot versions.
-Always check the documentation page for the specific Spring Cloud release train (e.g., 2023.0.1) to find its required
-Spring Boot version.
+## Spring Cloud &harr; Spring Boot
 
 | Spring Cloud Release Train                                                                                  | Corresponding Spring Boot Version                                             |
 | :---------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------- |
@@ -83,7 +57,9 @@ Spring Boot version.
 | Finchley                                                                                                    | Spring Boot 2.0.x                                                             |
 | Edgware                                                                                                     | Spring Boot 1.5.x                                                             |
 
-### Gradle and Java Compatibility
+Don't mix trains and Boot versions arbitrarily &mdash; always confirm against the specific release train's docs.
+
+## Gradle &harr; Java
 
 | Gradle Version | Latest Supported Java Version |
 | :------------- | :---------------------------- |
@@ -100,101 +76,11 @@ Spring Boot version.
 | 7.0            | Java 16                       |
 | 6.7            | Java 15                       |
 
-Key Points:
-
-- The table lists the Gradle version that _first_ added support for running on each Java release. The latest Gradle
-  release is 9.6 (June 2026), which can run on any JDK from 17 through 26.
-- Newer Gradle versions are generally required to support newer Java versions for running Gradle itself.
-- While you might run Gradle 9 on JDK 25, you can still configure it to compile your project code for Java 17 or Java 21
-  using toolchains.
-- Always check the specific Gradle version's documentation, as support details can change between minor releases.
-
-(https://docs.gradle.org/current/userguide/compatibility.html)
-
-## Why Version Compatibility is Necessary
-
-Spring Boot simplifies dependency management through its starters and managed dependencies (BOM). Spring Cloud builds on
-this, adding its own layer of managed dependencies. These systems work reliably when the versions are aligned because:
-
-- APIs Change: Libraries evolve. Methods get added, removed, or change signatures. Code compiled against one version may
-  fail at runtime if a different, incompatible version is present.
-- Bytecode Requirements: Newer Java versions introduce bytecode features older JVMs can't handle. Conversely, older
-  libraries might rely on APIs removed in newer JDKs. Your build tool (Gradle/Maven) also has minimum JDK requirements.
-- Transitive Dependencies: The dependencies managed by Spring Boot and Spring Cloud have their own dependencies. A
-  mismatch anywhere in this chain can cause conflicts.
-
-### Common Errors from Version Mismatches
-
-When versions aren't correctly aligned between Java, your build tool, Spring Boot, and potentially Spring Cloud, you
-might encounter errors like:
-
-- `java.lang.ClassNotFoundException`: The JVM can't find a specific class file at runtime. This often points to a missing
-  dependency or an incorrect version being loaded.
-- `java.lang.NoSuchMethodError`: Code calls a method that existed at compile time, but is missing in the version of the
-  library loaded at runtime. A classic sign of a version conflict.
-- `java.lang.AbstractMethodError`: An attempt was made to call an abstract method, which can happen if library APIs
-  changed between versions in incompatible ways.
-- Compilation Failures: Often related to using Java language features not supported by the configured
-  targetCompatibility bytecode level, or when Spring Boot/Cloud versions require APIs from a newer JDK than you're using.
-- Build Tool Errors: Gradle or Maven might fail if they are run with an incompatible JDK version (e.g., running Gradle 6
-  with JDK 17 might cause issues).
-- Spring Framework Issues: Problems like `UnsatisfiedDependencyException` or `BeanCreationException` during application
-  startup can sometimes stem from underlying library incompatibilities caused by version mismatches.
-
-### Resolving Compatibility Issues
-
-Troubleshooting version conflicts involves a systematic approach:
-
-- Consult Official Documentation: This is the primary source of truth. Check the specific version requirements for
-  Gradle, Spring Boot, and Spring Cloud.
-- Use Spring Initializr: For new projects, start.spring.io pre-selects compatible versions, providing a solid starting
-  point.
-- Utilize Maven/Gradle BOMs: Import the spring-boot-dependencies Bill of Materials (BOM) and, if used, the
-  spring-cloud-dependencies BOM for your specific release train. This helps ensure consistent versions for transitive
-  dependencies.
-
-Maven Example (pom.xml)
-
-```xml
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-dependencies</artifactId>
-            <version>${spring-cloud.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-dependencies</artifactId>
-            <version>${spring-boot.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
-```
-
-Gradle Example (build.gradle - using dependencyManagement plugin)
-
-```groovy
-dependencyManagement {
-    imports {
-        // Import the BOMs
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}" // Specify Cloud version
-        mavenBom "org.springframework.boot:spring-boot-dependencies:${springBootVersion}" // Specify Boot version
-    }
-}
-```
-
-- Inspect the Dependency Tree: Use `mvn dependency:tree` or `gradle dependencies` (or `gradle buildEnvironment`) to see
-  the resolved dependency versions. Identify conflicts where different versions of the same library are being requested.
-- Verify Build Tool Configuration: Ensure your Gradle or Maven setup is compatible with the JDK you're using to run the
-  build. For Gradle, explicitly configure Java toolchains for compiling and testing.
-- Test Consistently: Implement unit and integration tests to catch runtime errors early.
+Shows the Gradle version that _first_ added support for running on each Java release (latest is Gradle 9.6, June 2026).
+You can still target older bytecode via toolchains. Source:
+[Gradle compatibility docs](https://docs.gradle.org/current/userguide/compatibility.html).
 
 ---
 
-Disclaimer: Version compatibility information changes. Always refer to the official documentation for Gradle, Spring
-Boot, and Spring Cloud for the most accurate and up-to-date details pertinent to your project.
+Disclaimer: Version compatibility changes over time. Always confirm against the official Gradle, Spring Boot, and Spring
+Cloud documentation for your project.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -16,7 +16,11 @@ export interface Props {
   pubDatetime?: Date;
   modDatetime?: Date | null;
   scrollSmooth?: boolean;
-  schemaType?: "WebSite" | "BlogPosting" | "SoftwareApplication";
+  schemaType?:
+    | "WebSite"
+    | "BlogPosting"
+    | "SoftwareApplication"
+    | "TechArticle";
 }
 
 const {
@@ -47,7 +51,7 @@ const structuredData = {
   url: canonicalURL,
   ...(pubDatetime && { datePublished: pubDatetime.toISOString() }),
   ...(modDatetime && { dateModified: modDatetime.toISOString() }),
-  ...(schemaType === "BlogPosting" && {
+  ...((schemaType === "BlogPosting" || schemaType === "TechArticle") && {
     author: [
       {
         "@type": "Person",
@@ -91,8 +95,7 @@ const structuredData = {
       is:inline
       async
       src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9553425410079173"
-      crossorigin="anonymous"
-    ></script>
+      crossorigin="anonymous"></script>
     <script is:inline>
       function loadAds() {
         (window.adsbygoogle = window.adsbygoogle || []).push({});

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,13 +22,6 @@ const featuredProjects = allProjects
   .sort((a, b) => a.data.order - b.data.order)
   .slice(0, 3);
 
-const references = (
-  await getCollection("references", ({ data }) => !data.draft)
-).sort((a, b) => {
-  if (a.data.order !== b.data.order) return a.data.order - b.data.order;
-  return a.data.title.localeCompare(b.data.title);
-});
-
 const socialCount = SOCIALS.filter(social => social.active).length;
 
 const yoe = new Date().getFullYear() - 2016;
@@ -70,15 +63,6 @@ const yoe = new Date().getFullYear() - 2016;
       </p>
       <h4>Quick References</h4>
       <ul class="quick-ref-list">
-        {
-          references.map(reference => (
-            <li>
-              <a href={`/references/${reference.id}/`}>
-                {reference.data.title}
-              </a>
-            </li>
-          ))
-        }
         <li>
           <a href="https://spring.io/projects/generations"
             >Official Spring Dependency Matrix</a
@@ -86,7 +70,8 @@ const yoe = new Date().getFullYear() - 2016;
         </li>
       </ul>
       <p class="mt-1 text-sm opacity-80">
-        See all <a href="/references/" class="quick-ref-inline">references</a>.
+        Browse all <a href="/references/" class="quick-ref-inline">references</a
+        >.
       </p>
       {
         // only display if at least one social link is enabled

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,6 +22,13 @@ const featuredProjects = allProjects
   .sort((a, b) => a.data.order - b.data.order)
   .slice(0, 3);
 
+const references = (
+  await getCollection("references", ({ data }) => !data.draft)
+).sort((a, b) => {
+  if (a.data.order !== b.data.order) return a.data.order - b.data.order;
+  return a.data.title.localeCompare(b.data.title);
+});
+
 const socialCount = SOCIALS.filter(social => social.active).length;
 
 const yoe = new Date().getFullYear() - 2016;
@@ -61,19 +68,26 @@ const yoe = new Date().getFullYear() - 2016;
           >https://substack.com/@stevenpg1</a
         >
       </p>
-      <h4>Quick Reference Posts</h4>
+      <h4>Quick References</h4>
       <ul class="quick-ref-list">
-        <li>
-          <a href="/posts/spring-compat-cheatsheet/"
-            >Spring Version Compatibility Cheatsheet</a>
-        </li>
-      </ul>
-      <ul class="quick-ref-list">
+        {
+          references.map(reference => (
+            <li>
+              <a href={`/references/${reference.id}/`}>
+                {reference.data.title}
+              </a>
+            </li>
+          ))
+        }
         <li>
           <a href="https://spring.io/projects/generations"
-            >Official Spring Dependency Matrix</a>
+            >Official Spring Dependency Matrix</a
+          >
         </li>
       </ul>
+      <p class="mt-1 text-sm opacity-80">
+        See all <a href="/references/" class="quick-ref-inline">references</a>.
+      </p>
       {
         // only display if at least one social link is enabled
         socialCount > 0 && (
@@ -206,7 +220,8 @@ const yoe = new Date().getFullYear() - 2016;
   .quick-ref-list li {
     @apply my-1;
   }
-  .quick-ref-list a {
+  .quick-ref-list a,
+  .quick-ref-inline {
     @apply text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300;
   }
 

--- a/src/pages/references/[slug]/index.astro
+++ b/src/pages/references/[slug]/index.astro
@@ -1,0 +1,134 @@
+---
+import { getCollection, render } from "astro:content";
+import { SITE } from "@config";
+import Breadcrumbs from "@components/Breadcrumbs.astro";
+import Datetime from "@components/Datetime";
+import Footer from "@components/Footer.astro";
+import Header from "@components/Header.astro";
+import Tag from "@components/Tag.astro";
+import Layout from "@layouts/Layout.astro";
+import { slugifyStr } from "@utils/slugify";
+
+export async function getStaticPaths() {
+  const references = await getCollection(
+    "references",
+    ({ data }) => !data.draft
+  );
+
+  return references.map(reference => ({
+    params: { slug: reference.id },
+    props: { reference },
+  }));
+}
+
+const { reference } = Astro.props;
+const { title, description, tags, ogImage, pubDatetime, modDatetime } =
+  reference.data;
+const { Content } = await render(reference);
+
+const ogUrl = new URL(
+  ogImage ?? "/assets/default-og-image.png",
+  Astro.url.origin
+).href;
+---
+
+<Layout
+  title={`${title} | ${SITE.title}`}
+  description={description}
+  ogImage={ogUrl}
+  pubDatetime={pubDatetime}
+  modDatetime={modDatetime}
+  schemaType="TechArticle"
+  scrollSmooth={true}
+>
+  <Header activeNav="references" />
+  <Breadcrumbs />
+  <main id="main-content">
+    <h1 class="reference-title">{title}</h1>
+    <Datetime
+      pubDatetime={pubDatetime}
+      modDatetime={modDatetime}
+      size="lg"
+      className="my-2"
+    />
+    <p class="reference-evergreen">
+      <span aria-hidden="true">&#9851;</span> This is a living reference page &mdash;
+      I keep it updated as versions and details change.
+    </p>
+
+    <article id="article" class="prose mx-auto mt-8 max-w-3xl">
+      <Content />
+    </article>
+
+    <ul class="my-8">
+      {tags.map(tag => <Tag tag={slugifyStr(tag)} />)}
+    </ul>
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  main {
+    @apply mx-auto w-full max-w-3xl px-4 pb-12;
+  }
+  .reference-title {
+    @apply mt-8 text-2xl font-semibold text-skin-accent;
+  }
+  .reference-evergreen {
+    @apply mt-4 rounded-lg border border-skin-line bg-skin-card px-4 py-3 text-sm opacity-90;
+  }
+</style>
+
+<script is:inline data-astro-rerun>
+  /** Attaches links to headings, allowing easy section sharing. */
+  function addHeadingLinks() {
+    const headings = Array.from(
+      document.querySelectorAll("#article h2, #article h3, #article h4")
+    );
+    for (const heading of headings) {
+      if (!heading.id) continue;
+      heading.classList.add("group");
+      const link = document.createElement("a");
+      link.className =
+        "heading-link ml-2 opacity-0 group-hover:opacity-100 focus:opacity-100";
+      link.href = "#" + heading.id;
+      const span = document.createElement("span");
+      span.ariaHidden = "true";
+      span.innerText = "#";
+      link.appendChild(span);
+      heading.appendChild(link);
+    }
+  }
+  addHeadingLinks();
+
+  /** Attaches copy buttons to code blocks. */
+  function attachCopyButtons() {
+    const copyButtonLabel = "Copy";
+    const codeBlocks = Array.from(document.querySelectorAll("pre"));
+
+    for (const codeBlock of codeBlocks) {
+      const wrapper = document.createElement("div");
+      wrapper.style.position = "relative";
+
+      const copyButton = document.createElement("button");
+      copyButton.className =
+        "copy-code absolute right-3 -top-3 rounded bg-skin-card px-2 py-1 text-xs leading-4 text-skin-base font-medium";
+      copyButton.innerHTML = copyButtonLabel;
+      codeBlock.setAttribute("tabindex", "0");
+      codeBlock.appendChild(copyButton);
+
+      codeBlock?.parentNode?.insertBefore(wrapper, codeBlock);
+      wrapper.appendChild(codeBlock);
+
+      copyButton.addEventListener("click", async () => {
+        const code = codeBlock.querySelector("code");
+        await navigator.clipboard.writeText(code?.innerText ?? "");
+        copyButton.innerText = "Copied";
+        setTimeout(() => {
+          copyButton.innerText = copyButtonLabel;
+        }, 700);
+      });
+    }
+  }
+  attachCopyButtons();
+</script>

--- a/src/pages/references/[slug]/index.astro
+++ b/src/pages/references/[slug]/index.astro
@@ -77,6 +77,46 @@ const ogUrl = new URL(
   .reference-evergreen {
     @apply mt-4 rounded-lg border border-skin-line bg-skin-card px-4 py-3 text-sm opacity-90;
   }
+
+  /* Collapsible reference boxes (e.g. per-version entries) */
+  :global(.prose details.ref-box) {
+    @apply mb-4 rounded-xl border border-skin-line bg-skin-card transition-colors;
+  }
+  :global(.prose details.ref-box[open]) {
+    @apply border-skin-accent/50;
+  }
+  :global(.prose details.ref-box > summary) {
+    @apply flex cursor-pointer list-none items-center gap-3 rounded-xl px-5 py-4 font-semibold;
+  }
+  :global(.prose details.ref-box > summary::-webkit-details-marker) {
+    display: none;
+  }
+  :global(.prose details.ref-box > summary::after) {
+    content: "+";
+    @apply ml-auto text-xl font-normal text-skin-accent transition-transform;
+  }
+  :global(.prose details.ref-box[open] > summary::after) {
+    content: "−";
+  }
+  :global(.prose .ref-box-title) {
+    @apply text-lg text-skin-accent;
+  }
+  :global(.prose .ref-box-date) {
+    @apply text-sm font-normal opacity-70;
+  }
+  :global(.prose .ref-box-lts) {
+    @apply rounded-full bg-green-600/15 px-2.5 py-0.5 text-xs font-semibold text-green-700 dark:text-green-400;
+  }
+  /* Pad the body and tidy list spacing inside boxes */
+  :global(.prose details.ref-box > *:not(summary)) {
+    @apply px-5;
+  }
+  :global(.prose details.ref-box > *:not(summary):last-child) {
+    @apply pb-5;
+  }
+  :global(.prose details.ref-box > ul) {
+    @apply mt-0;
+  }
 </style>
 
 <script is:inline data-astro-rerun>

--- a/src/pages/references/index.astro
+++ b/src/pages/references/index.astro
@@ -1,0 +1,79 @@
+---
+import { getCollection } from "astro:content";
+import { SITE } from "@config";
+import Breadcrumbs from "@components/Breadcrumbs.astro";
+import Footer from "@components/Footer.astro";
+import Header from "@components/Header.astro";
+import Layout from "@layouts/Layout.astro";
+
+const references = (
+  await getCollection("references", ({ data }) => !data.draft)
+).sort((a, b) => {
+  if (a.data.order !== b.data.order) return a.data.order - b.data.order;
+  return a.data.title.localeCompare(b.data.title);
+});
+
+const formatDate = (date: Date) =>
+  date.toLocaleDateString("en-EN", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+---
+
+<Layout
+  title={`References | ${SITE.title}`}
+  description="Continuously updated reference pages, cheatsheets, and lookup tables I keep current and return to often."
+>
+  <Header activeNav="references" />
+  <Breadcrumbs />
+  <main id="main-content">
+    <section class="mb-28 max-w-3xl">
+      <h1 class="text-3xl tracking-wider sm:text-4xl">References</h1>
+      <p class="mt-4 mb-10 opacity-80">
+        Living reference pages I keep continuously updated &mdash; cheatsheets,
+        compatibility matrices, and lookup tables worth bookmarking rather than
+        reading once.
+      </p>
+      <ul class="flex flex-col gap-5">
+        {
+          references.map(reference => (
+            <li>
+              <a
+                href={`/references/${reference.id}/`}
+                class="group block rounded-xl border border-skin-line bg-skin-card p-5 transition-all hover:border-skin-accent/50"
+              >
+                <h2 class="text-xl font-semibold text-skin-accent">
+                  {reference.data.title}
+                </h2>
+                <p class="mt-2 text-sm opacity-80">
+                  {reference.data.description}
+                </p>
+                <div class="mt-3 flex flex-wrap items-center gap-2">
+                  {reference.data.tags.map(tag => (
+                    <span class="rounded-full bg-skin-card-muted px-3 py-0.5 text-xs font-medium opacity-90">
+                      {tag}
+                    </span>
+                  ))}
+                  <span class="ml-auto text-xs italic opacity-70">
+                    Updated{" "}
+                    {formatDate(
+                      reference.data.modDatetime ?? reference.data.pubDatetime
+                    )}
+                  </span>
+                </div>
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+  </main>
+  <Footer />
+</Layout>
+
+<style>
+  #main-content {
+    @apply mx-auto max-w-3xl px-4;
+  }
+</style>


### PR DESCRIPTION
Introduce a new evergreen "references" content collection for
continuously-updated pages (cheatsheets, lookup tables), distinct
from dated blog posts:

- New `references` collection in content.config.ts
- /references/ listing page and /references/<slug>/ detail page
  (TechArticle JSON-LD with dateModified for freshness signals)
- "References" nav tab in the header
- Homepage Quick References section is now data-driven off the
  collection so new references appear automatically
- First reference: Spring Version Compatibility Cheatsheet
- Point the old blog post at the new page via canonicalURL and a
  callout note at the top (consolidates SEO onto the live page)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T92fvuNW4FT67z5ww28Lzs