### PR TITLE
Update reference pages with July 2026 versions

### DIFF
--- a/src/content/references/go-version-guide.md
+++ b/src/content/references/go-version-guide.md
@@ -3,7 +3,7 @@ title: Go Version Guide
 description: What's new in each major Go release, with support status marked and links to release notes.
 slug: go-version-guide
 pubDatetime: 2026-06-26T12:00:00.000Z
-modDatetime: 2026-06-26T12:00:00.000Z
+modDatetime: 2026-07-18T12:00:00.000Z
 tags:
   - golang
 order: 2
@@ -36,7 +36,13 @@ painless.
 | [1.5](https://go.dev/doc/go1.5)        | Aug 2015 | Compiler & runtime rewritten in Go, concurrent low-latency GC, `GOMAXPROCS` defaults to all CPUs                 |
 | [1.0](https://go.dev/doc/go1)          | Mar 2012 | First stable release &mdash; the Go 1 compatibility guarantee begins                                             |
 
-> **[Go 1.27](https://go.dev/doc/go1.27)** is expected around **August 2026**. Work-in-progress release notes are already published — highlights include generic methods, `encoding/json/v2` GA, a new `uuid` package, `crypto/mldsa` (post-quantum ML-DSA), and ~30% faster small allocations. See the [release history](https://go.dev/doc/devel/release) for the latest published versions and the [milestone tracker](https://github.com/golang/go/milestones) for what's landing.
+> **[Go 1.27](https://go.dev/doc/go1.27)** is expected in **August 2026**, and as of mid-July 2026 the **first release
+> candidate is out**. Highlights from the draft release notes: **generic methods** (methods can declare their own type
+> parameters), `encoding/json/v2` GA, a new `uuid` package, `crypto/mldsa` (post-quantum ML-DSA), struct literal keys
+> can be any field selector, generalized function type inference, `go mod tidy` merging duplicate `require` blocks, the
+> `stdversion` vet check on by default in `go test`, and ~30% faster small allocations. macOS 13+ is now required. See
+> the [release history](https://go.dev/doc/devel/release) for published versions and the
+> [milestone tracker](https://github.com/golang/go/milestones) for what's landing.
 
 ## How Go Support Works
 

--- a/src/content/references/java-version-guide.md
+++ b/src/content/references/java-version-guide.md
@@ -3,7 +3,7 @@ title: Java Version Guide
 description: What's new in each Java release from 8 onward, with LTS versions marked and links to release notes.
 slug: java-version-guide
 pubDatetime: 2026-06-26T12:00:00.000Z
-modDatetime: 2026-06-26T12:00:00.000Z
+modDatetime: 2026-07-18T12:00:00.000Z
 tags:
   - java
 order: 1
@@ -13,13 +13,28 @@ A "what's new" for every Java feature release since Java 8. Since Java 9, a feat
 (March and September). **LTS** (Long-Term Support) releases &mdash; the ones most teams standardize on &mdash; now
 arrive every **two years**; earlier they were three years apart.
 
-**LTS line:** 8 &middot; 11 &middot; 17 &middot; 21 &middot; 25 (next: **27** in 2027). Expand any release below for its
+**LTS line:** 8 &middot; 11 &middot; 17 &middot; 21 &middot; 25 (next: **29** in September 2027, per
+[Oracle's roadmap](https://www.oracle.com/java/technologies/java-se-support-roadmap.html)). Expand any release below for its
 highlights and a link to the release notes. For the complete picture of any version, see the
 [JEP index](https://openjdk.org/jeps/0).
 
 ## Releases
 
 <details class="ref-box" open>
+<summary><span class="ref-box-title">Java 26</span><span class="ref-box-date">Mar 2026</span></summary>
+
+- **HTTP/3 for the HTTP Client API** — talk to HTTP/3 servers with minimal code change ([JEP 517](https://openjdk.org/jeps/517))
+- **Ahead-of-time object caching with any GC** — Project Leyden's AOT cache now works with ZGC and friends ([JEP 516](https://openjdk.org/jeps/516))
+- **G1 throughput boost** — dual card tables cut synchronization; 5–15% gains for write-heavy apps ([JEP 522](https://openjdk.org/jeps/522))
+- **Warnings for deep-reflection mutation of final fields** — first step toward making `final` really mean final ([JEP 500](https://openjdk.org/jeps/500))
+- The **Applet API is gone** at last ([JEP 504](https://openjdk.org/jeps/504))
+- Still in preview/incubator: lazy constants (formerly stable values, [JEP 526](https://openjdk.org/jeps/526)), structured concurrency ([JEP 525](https://openjdk.org/jeps/525)), primitive types in patterns ([JEP 530](https://openjdk.org/jeps/530)), PEM encodings ([JEP 524](https://openjdk.org/jeps/524)), Vector API ([JEP 529](https://openjdk.org/jeps/529))
+
+[Release notes →](https://openjdk.org/projects/jdk/26/)
+
+</details>
+
+<details class="ref-box">
 <summary><span class="ref-box-title">Java 25</span><span class="ref-box-date">Sep 2025</span><span class="ref-box-lts">LTS</span></summary>
 
 - **Flexible constructor bodies** — run statements before `this()`/`super()` ([JEP 513](https://openjdk.org/jeps/513))
@@ -213,8 +228,15 @@ highlights and a link to the release notes. For the complete picture of any vers
 
 </details>
 
-> **Java 26** is the next feature release, targeted for **March 2026** (non-LTS; the next LTS is **Java 27** in
-> September 2027). Check the [OpenJDK JDK project page](https://openjdk.org/projects/jdk/) for its finalized JEPs.
+> **Java 27** (non-LTS) is the next feature release, due **September 2026**. As of mid-July 2026 its feature set is
+> frozen (Rampdown Phase One began June 4) at nine JEPs. The headliners: **compact object headers on by default**
+> ([JEP 534](https://openjdk.org/jeps/534)), **G1 as the default GC in all environments** ([JEP 523](https://openjdk.org/jeps/523)),
+> **post-quantum hybrid key exchange for TLS 1.3** ([JEP 527](https://openjdk.org/jeps/527)), and **JFR in-process data
+> redaction** ([JEP 536](https://openjdk.org/jeps/536)). The rest are re-runs: lazy constants
+> ([JEP 531](https://openjdk.org/jeps/531)), primitive type patterns ([JEP 532](https://openjdk.org/jeps/532)),
+> structured concurrency ([JEP 533](https://openjdk.org/jeps/533)), PEM encodings ([JEP 538](https://openjdk.org/jeps/538)),
+> and a twelfth Vector API incubation ([JEP 537](https://openjdk.org/jeps/537)). See the
+> [JDK 27 project page](https://openjdk.org/projects/jdk/27/) for the latest.
 
 ## How Java Support Works
 

--- a/src/content/references/python-version-guide.md
+++ b/src/content/references/python-version-guide.md
@@ -3,7 +3,7 @@ title: Python Version Guide
 description: What's new in each Python 3 release, with support status marked and links to the official What's New notes.
 slug: python-version-guide
 pubDatetime: 2026-06-26T12:00:00.000Z
-modDatetime: 2026-06-26T12:00:00.000Z
+modDatetime: 2026-07-18T12:00:00.000Z
 tags:
   - python
 order: 3
@@ -30,7 +30,12 @@ A scannable "what's new" for modern Python 3 releases. Python ships one feature 
 | [3.7](https://docs.python.org/3/whatsnew/3.7.html)             | Jun 2018 | End of life   | `dataclasses`, `breakpoint()`, deferred annotation imports, guaranteed dict ordering                      |
 | [3.6](https://docs.python.org/3/whatsnew/3.6.html)             | Dec 2016 | End of life   | **f-strings**, variable annotations, async generators & comprehensions, `secrets`                         |
 
-> **Python 3.15** is due **October 2026**. Status labels above are approximate &mdash; the
+> **[Python 3.15](https://docs.python.org/3.15/whatsnew/3.15.html)** is due **October 1, 2026**, and as of mid-July
+> 2026 it's feature-frozen and in beta. Headliners: **explicit lazy imports**
+> ([PEP 810](https://peps.python.org/pep-0810/) &mdash; faster startup for big dependency trees), a **stable ABI for
+> free-threaded CPython**, a noticeably faster JIT (~8&ndash;13% on the benchmark suite), a new zero-overhead sampling
+> profiler, UTF-8 as the default text encoding ([PEP 686](https://peps.python.org/pep-0686/)), and a colorized CLI with
+> SQL keyword tab-completion in `sqlite3`. Status labels above are approximate &mdash; the
 > [devguide version page](https://devguide.python.org/versions/) is the source of truth for bugfix vs. security-only vs.
 > EOL dates.
 

--- a/src/content/references/spring-version-compatibility.md
+++ b/src/content/references/spring-version-compatibility.md
@@ -3,7 +3,7 @@ title: Spring Version Compatibility Cheatsheet
 description: A continuously updated reference for aligning Java, Gradle, Spring Boot, and Spring Cloud versions.
 slug: spring-version-compatibility
 pubDatetime: 2025-05-04T12:00:00.000Z
-modDatetime: 2026-06-26T12:00:00.000Z
+modDatetime: 2026-07-18T12:00:00.000Z
 tags:
   - gradle
   - java
@@ -38,7 +38,8 @@ ship &mdash; bookmark it. For the official, authoritative matrix, see Spring's
 | 2.0.x               | Java 8 - 9                                    |
 | 1.5.x               | Java 6 - 8                                    |
 
-Spring Boot 4.x and 3.x baseline on Java 17. Source:
+Spring Boot 4.x and 3.x baseline on Java 17. As of July 2026, only **4.1.x** (released June 2026) and **4.0.x** are in
+open-source support &mdash; **3.5.x reached OSS end-of-life on June 30, 2026** (commercial support continues). Source:
 [endoflife.date](https://endoflife.date/spring-boot#java-compatibility).
 
 ## Spring Cloud &harr; Spring Boot
@@ -57,7 +58,10 @@ Spring Boot 4.x and 3.x baseline on Java 17. Source:
 | Finchley                                                                                                    | Spring Boot 2.0.x                                                             |
 | Edgware                                                                                                     | Spring Boot 1.5.x                                                             |
 
-Don't mix trains and Boot versions arbitrarily &mdash; always confirm against the specific release train's docs.
+Don't mix trains and Boot versions arbitrarily &mdash; always confirm against the specific release train's docs. As of
+July 2026 the current train is **Oakwood** (latest patch:
+[2025.1.2](https://spring.io/blog/2026/06/11/spring-cloud-2025-1-2-aka-oakwood-has-been-released/), June 2026, adding
+Spring Boot 4.1 compatibility); the next train, codenamed **Paddington**, will track Spring Boot 4.2.
 
 ## Gradle &harr; Java
 
@@ -76,8 +80,9 @@ Don't mix trains and Boot versions arbitrarily &mdash; always confirm against th
 | 7.0            | Java 16                       |
 | 6.7            | Java 15                       |
 
-Shows the Gradle version that _first_ added support for running on each Java release (latest is Gradle 9.6, June 2026).
-You can still target older bytecode via toolchains. Source:
+Shows the Gradle version that _first_ added support for running on each Java release (latest is Gradle 9.6.1, July
+2026). As of July 2026 no Gradle release runs on Java 27 yet &mdash; you can still compile/test against newer JDKs via
+toolchains while running Gradle itself on Java 17&ndash;26. Source:
 [Gradle compatibility docs](https://docs.gradle.org/current/userguide/compatibility.html).
 
 ---


### PR DESCRIPTION
- Java: add Java 26 release box (HTTP/3, AOT object caching, G1 throughput),
  detail the frozen JDK 27 feature set, and correct the next LTS to Java 29
- Go: note Go 1.27 RC1 with confirmed draft release-note highlights
- Python: expand the 3.15 preview (lazy imports, free-threaded ABI, faster JIT)
- Spring: note Boot 3.5 OSS EOL, Spring Cloud 2025.1.2 / Paddington, Gradle 9.6.1
  and Java 27 status

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BdN84gnn5HD4wpwbjrKnWE