### PR TITLE
Add Link Roundup section to references page

### DIFF
--- a/src/data/referenceLinks.ts
+++ b/src/data/referenceLinks.ts
@@ -1,0 +1,33 @@
+export type ReferenceLink = {
+  title: string;
+  url: string;
+  description?: string;
+};
+
+export type ReferenceLinkSection = {
+  section: string;
+  links: ReferenceLink[];
+};
+
+/**
+ * Quick-hit external links worth bookmarking, grouped by topic.
+ * Unlike the reference pages above, these aren't authored/maintained content
+ * -- just useful things to find again. Add new entries wherever they fit.
+ */
+export const referenceLinkSections: ReferenceLinkSection[] = [
+  {
+    section: "Go",
+    links: [
+      {
+        title: "100 Go Mistakes",
+        url: "https://100go.co/",
+        description: "Common Go mistakes and how to avoid them.",
+      },
+      {
+        title: "Idiomatic Go",
+        url: "https://dmitri.shuralyov.com/idiomatic-go",
+        description: "A collection of common Go idioms and style tips.",
+      },
+    ],
+  },
+];

--- a/src/pages/references/index.astro
+++ b/src/pages/references/index.astro
@@ -5,6 +5,7 @@ import Breadcrumbs from "@components/Breadcrumbs.astro";
 import Footer from "@components/Footer.astro";
 import Header from "@components/Header.astro";
 import Layout from "@layouts/Layout.astro";
+import { referenceLinkSections } from "@data/referenceLinks";
 
 const references = (
   await getCollection("references", ({ data }) => !data.draft)
@@ -30,7 +31,7 @@ const formatDate = (date: Date) =>
   <main id="main-content">
     <section class="mb-28 max-w-3xl">
       <h1 class="text-3xl tracking-wider sm:text-4xl">References</h1>
-      <p class="mt-4 mb-10 opacity-80">
+      <p class="mb-10 mt-4 opacity-80">
         Living reference pages I keep continuously updated &mdash; cheatsheets,
         compatibility matrices, and lookup tables worth bookmarking rather than
         reading once.
@@ -67,6 +68,44 @@ const formatDate = (date: Date) =>
           ))
         }
       </ul>
+    </section>
+
+    <section class="mb-28 max-w-3xl">
+      <h2 class="text-2xl tracking-wider sm:text-3xl">Link Roundup</h2>
+      <p class="mb-10 mt-4 opacity-80">
+        Assorted external links I keep coming back to &mdash; not maintained by
+        me, just worth bookmarking.
+      </p>
+      <div class="flex flex-col gap-8">
+        {
+          referenceLinkSections.map(({ section, links }) => (
+            <div>
+              <h3 class="text-lg font-semibold text-skin-accent">{section}</h3>
+              <ul class="mt-3 flex flex-col gap-3">
+                {links.map(link => (
+                  <li>
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="group block rounded-xl border border-skin-line bg-skin-card p-4 transition-all hover:border-skin-accent/50"
+                    >
+                      <span class="font-medium text-skin-accent group-hover:underline">
+                        {link.title}
+                      </span>
+                      {link.description && (
+                        <p class="mt-1 text-sm opacity-80">
+                          {link.description}
+                        </p>
+                      )}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))
+        }
+      </div>
     </section>
   </main>
   <Footer />


### PR DESCRIPTION
## Summary
Adds a new "Link Roundup" section to the references page that displays curated external links organized by topic, complementing the existing authored reference pages.

## Changes
- **New data file** (`src/data/referenceLinks.ts`): Defines `ReferenceLink` and `ReferenceLinkSection` types, and exports a `referenceLinkSections` array containing external links grouped by category (starting with Go resources)
- **Updated references page** (`src/pages/references/index.astro`):
  - Imports the new `referenceLinkSections` data
  - Adds a new "Link Roundup" section below the existing references list
  - Renders links in a card-based layout with hover effects, supporting optional descriptions
  - Minor style adjustment: reordered Tailwind classes on the introductory paragraph for consistency

## Implementation Details
- Links open in a new tab with `target="_blank"` and `rel="noopener noreferrer"` for security
- Each link displays as a styled card with the title, optional description, and hover state that highlights the accent color
- The structure allows easy addition of new link categories and entries to `referenceLinkSections`
- Follows existing design patterns from the site's component library (skin-based color variables, spacing utilities)

https://claude.ai/code/session_01FhSikR6Lq4DKayFeBncqiz