### PR TITLE
Update reference pages with August 2026 versions

### DIFF
--- a/src/content/references/go-version-guide.md
+++ b/src/content/references/go-version-guide.md
@@ -3,7 +3,7 @@ title: Go Version Guide
 description: What's new in each major Go release, with support status marked and links to release notes.
 slug: go-version-guide
 pubDatetime: 2026-06-26T12:00:00.000Z
-modDatetime: 2026-07-18T12:00:00.000Z
+modDatetime: 2026-08-11T12:00:00.000Z
 tags:
   - golang
 order: 2
@@ -36,12 +36,15 @@ painless.
 | [1.5](https://go.dev/doc/go1.5)        | Aug 2015 | Compiler & runtime rewritten in Go, concurrent low-latency GC, `GOMAXPROCS` defaults to all CPUs                 |
 | [1.0](https://go.dev/doc/go1)          | Mar 2012 | First stable release &mdash; the Go 1 compatibility guarantee begins                                             |
 
-> **[Go 1.27](https://go.dev/doc/go1.27)** is expected in **August 2026**, and as of mid-July 2026 the **first release
-> candidate is out**. Highlights from the draft release notes: **generic methods** (methods can declare their own type
-> parameters), `encoding/json/v2` GA, a new `uuid` package, `crypto/mldsa` (post-quantum ML-DSA), struct literal keys
-> can be any field selector, generalized function type inference, `go mod tidy` merging duplicate `require` blocks, the
-> `stdversion` vet check on by default in `go test`, and ~30% faster small allocations. macOS 13+ is now required. See
-> the [release history](https://go.dev/doc/devel/release) for published versions and the
+> **[Go 1.27](https://go.dev/doc/go1.27)** is expected in **August 2026**; as of mid-August the latest stable release
+> is still 1.26.x and **release candidate 2** (July 7) is the newest 1.27 build. Highlights from the draft release
+> notes: **generic methods** (methods can declare their own type parameters), **`encoding/json/v2` GA** &mdash;
+> `encoding/json` is now backed by the v2 implementation, with `GOEXPERIMENT=nojsonv2` as a temporary opt-out &mdash; a
+> new `uuid` package, `crypto/mldsa` (post-quantum ML-DSA), an experimental `simd` package (`GOEXPERIMENT=simd`),
+> generally available goroutine leak profiles, struct literal keys as any field selector, generalized function type
+> inference, `go mod tidy` merging duplicate `require` blocks, the `stdversion` vet check on by default in `go test`,
+> and ~30% faster small allocations. macOS 13 Ventura or later is now required. See the
+> [release history](https://go.dev/doc/devel/release) for published versions and the
 > [milestone tracker](https://github.com/golang/go/milestones) for what's landing.
 
 ## How Go Support Works

--- a/src/content/references/java-version-guide.md
+++ b/src/content/references/java-version-guide.md
@@ -3,7 +3,7 @@ title: Java Version Guide
 description: What's new in each Java release from 8 onward, with LTS versions marked and links to release notes.
 slug: java-version-guide
 pubDatetime: 2026-06-26T12:00:00.000Z
-modDatetime: 2026-07-18T12:00:00.000Z
+modDatetime: 2026-08-11T12:00:00.000Z
 tags:
   - java
 order: 1
@@ -228,8 +228,10 @@ highlights and a link to the release notes. For the complete picture of any vers
 
 </details>
 
-> **Java 27** (non-LTS) is the next feature release, due **September 2026**. As of mid-July 2026 its feature set is
-> frozen (Rampdown Phase One began June 4) at nine JEPs. The headliners: **compact object headers on by default**
+> **Java 27** (non-LTS) is the next feature release, with GA targeted for **September 15, 2026**. As of early August
+> 2026 it's in Rampdown Phase Two (began July 16) with the feature set frozen at nine JEPs; the initial release
+> candidate slipped from August 6 to **August 20** so it lands after the quarterly Critical Patch Update, leaving about
+> three weeks of RC feedback instead of five. The headliners: **compact object headers on by default**
 > ([JEP 534](https://openjdk.org/jeps/534)), **G1 as the default GC in all environments** ([JEP 523](https://openjdk.org/jeps/523)),
 > **post-quantum hybrid key exchange for TLS 1.3** ([JEP 527](https://openjdk.org/jeps/527)), and **JFR in-process data
 > redaction** ([JEP 536](https://openjdk.org/jeps/536)). The rest are re-runs: lazy constants

--- a/src/content/references/python-version-guide.md
+++ b/src/content/references/python-version-guide.md
@@ -3,7 +3,7 @@ title: Python Version Guide
 description: What's new in each Python 3 release, with support status marked and links to the official What's New notes.
 slug: python-version-guide
 pubDatetime: 2026-06-26T12:00:00.000Z
-modDatetime: 2026-07-18T12:00:00.000Z
+modDatetime: 2026-08-11T12:00:00.000Z
 tags:
   - python
 order: 3
@@ -30,12 +30,16 @@ A scannable "what's new" for modern Python 3 releases. Python ships one feature 
 | [3.7](https://docs.python.org/3/whatsnew/3.7.html)             | Jun 2018 | End of life   | `dataclasses`, `breakpoint()`, deferred annotation imports, guaranteed dict ordering                      |
 | [3.6](https://docs.python.org/3/whatsnew/3.6.html)             | Dec 2016 | End of life   | **f-strings**, variable annotations, async generators & comprehensions, `secrets`                         |
 
-> **[Python 3.15](https://docs.python.org/3.15/whatsnew/3.15.html)** is due **October 1, 2026**, and as of mid-July
-> 2026 it's feature-frozen and in beta. Headliners: **explicit lazy imports**
-> ([PEP 810](https://peps.python.org/pep-0810/) &mdash; faster startup for big dependency trees), a **stable ABI for
-> free-threaded CPython**, a noticeably faster JIT (~8&ndash;13% on the benchmark suite), a new zero-overhead sampling
-> profiler, UTF-8 as the default text encoding ([PEP 686](https://peps.python.org/pep-0686/)), and a colorized CLI with
-> SQL keyword tab-completion in `sqlite3`. Status labels above are approximate &mdash; the
+> **[Python 3.15](https://docs.python.org/3.15/whatsnew/3.15.html)** is due **October 1, 2026**. **Release candidate 1
+> landed August 4, 2026** and rc2 is scheduled for September 1, so the feature set is locked. Headliners: **explicit
+> lazy imports** ([PEP 810](https://peps.python.org/pep-0810/) &mdash; faster startup for big dependency trees),
+> **UTF-8 as the default text encoding** ([PEP 686](https://peps.python.org/pep-0686/) &mdash; `open()` no longer
+> follows the locale), new `frozendict` ([PEP 814](https://peps.python.org/pep-0814/)) and `sentinel`
+> ([PEP 661](https://peps.python.org/pep-0661/)) builtins, unpacking in comprehensions
+> ([PEP 798](https://peps.python.org/pep-0798/)), a dedicated profiling package with the Tachyon sampling profiler
+> ([PEP 799](https://peps.python.org/pep-0799/)), frame pointers on by default
+> ([PEP 831](https://peps.python.org/pep-0831/)), a **stable ABI for free-threaded CPython**, and a noticeably faster
+> JIT (~8&ndash;13% on the benchmark suite). Status labels above are approximate &mdash; the
 > [devguide version page](https://devguide.python.org/versions/) is the source of truth for bugfix vs. security-only vs.
 > EOL dates.
 
@@ -45,6 +49,8 @@ A scannable "what's new" for modern Python 3 releases. Python ships one feature 
   patches until it reaches roughly 5 years old.
 - The **latest one or two releases** are the ones receiving regular bug fixes (the "Active" rows above). Older supported
   versions get security fixes only.
+- **3.10 goes end-of-life in October 2026**, right around the 3.15 release &mdash; if you're still on it, plan the jump
+  now.
 - **Free-threading** (PEP 703 / 779) is the big ongoing shift: experimental in 3.13, officially supported in 3.14. It
   removes the GIL but is still opt-in via a separate build.
 

--- a/src/content/references/spring-version-compatibility.md
+++ b/src/content/references/spring-version-compatibility.md
@@ -3,7 +3,7 @@ title: Spring Version Compatibility Cheatsheet
 description: A continuously updated reference for aligning Java, Gradle, Spring Boot, and Spring Cloud versions.
 slug: spring-version-compatibility
 pubDatetime: 2025-05-04T12:00:00.000Z
-modDatetime: 2026-07-18T12:00:00.000Z
+modDatetime: 2026-08-11T12:00:00.000Z
 tags:
   - gradle
   - java
@@ -38,9 +38,10 @@ ship &mdash; bookmark it. For the official, authoritative matrix, see Spring's
 | 2.0.x               | Java 8 - 9                                    |
 | 1.5.x               | Java 6 - 8                                    |
 
-Spring Boot 4.x and 3.x baseline on Java 17. As of July 2026, only **4.1.x** (released June 2026) and **4.0.x** are in
-open-source support &mdash; **3.5.x reached OSS end-of-life on June 30, 2026** (commercial support continues). Source:
-[endoflife.date](https://endoflife.date/spring-boot#java-compatibility).
+Spring Boot 4.x and 3.x baseline on Java 17. As of August 2026, only **4.1.x** (released June 2026) and **4.0.x** are in
+open-source support &mdash; 4.0.x until **December 31, 2026** and 4.1.x until **July 31, 2027**. **3.5.x reached OSS
+end-of-life on June 30, 2026** (commercial support continues). The next feature release, **4.2**, is expected in
+November 2026. Source: [endoflife.date](https://endoflife.date/spring-boot#java-compatibility).
 
 ## Spring Cloud &harr; Spring Boot
 
@@ -59,9 +60,10 @@ open-source support &mdash; **3.5.x reached OSS end-of-life on June 30, 2026** (
 | Edgware                                                                                                     | Spring Boot 1.5.x                                                             |
 
 Don't mix trains and Boot versions arbitrarily &mdash; always confirm against the specific release train's docs. As of
-July 2026 the current train is **Oakwood** (latest patch:
+August 2026 the current train is **Oakwood** (latest patch:
 [2025.1.2](https://spring.io/blog/2026/06/11/spring-cloud-2025-1-2-aka-oakwood-has-been-released/), June 2026, adding
-Spring Boot 4.1 compatibility); the next train, codenamed **Paddington**, will track Spring Boot 4.2.
+Spring Boot 4.1 compatibility); the next train, **2026.0.x (Paddington)**, is in milestones against Spring Boot 4.2 and
+should ship alongside it.
 
 ## Gradle &harr; Java
 
@@ -80,9 +82,10 @@ Spring Boot 4.1 compatibility); the next train, codenamed **Paddington**, will t
 | 7.0            | Java 16                       |
 | 6.7            | Java 15                       |
 
-Shows the Gradle version that _first_ added support for running on each Java release (latest is Gradle 9.6.1, July
-2026). As of July 2026 no Gradle release runs on Java 27 yet &mdash; you can still compile/test against newer JDKs via
-toolchains while running Gradle itself on Java 17&ndash;26. Source:
+Shows the Gradle version that _first_ added support for running on each Java release (latest is Gradle 9.7, August
+2026). As of August 2026 no Gradle release runs on Java 27 yet &mdash; the compatibility docs still list JVM 27 as
+unsupported, and Java 27 itself isn't GA until September. You can still compile/test against newer JDKs via toolchains
+while running Gradle itself on Java 17&ndash;26. Source:
 [Gradle compatibility docs](https://docs.gradle.org/current/userguide/compatibility.html).
 
 ---


### PR DESCRIPTION
- Spring/Gradle cheatsheet: Spring Boot 4.0 OSS EOL (Dec 2026) and 4.1
  (Jul 2027) dates, 4.2 expected Nov 2026; Spring Cloud next train named
  as 2026.0.x (Paddington) in milestones against Boot 4.2; Gradle latest
  bumped to 9.7 (Aug 2026), still no JVM 27 support
- Java: JDK 27 now in Rampdown Phase Two, initial RC moved to Aug 20 to
  land after the quarterly CPU, GA targeted Sep 15, 2026
- Go: 1.27 still unreleased with rc2 as newest build; json/v2 GA details,
  experimental simd package, goroutine leak profiles, macOS 13 baseline
- Python: 3.15.0rc1 (Aug 4) and rc2 (Sep 1) schedule, refreshed feature
  list with PEP links, note that 3.10 goes EOL in October 2026

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XniQPCjX8nqQqrE122CJ5n